### PR TITLE
feat: password and security 페이지 UI 구현

### DIFF
--- a/app/password-and-security/page.tsx
+++ b/app/password-and-security/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { PasswordForm } from '~/components/password-and-security/password-form'
+
+function PasswordAndSecurity() {
+  return (
+    <div className="h-screen">
+      <div className="m-auto w-2/3 pt-10">
+        <h2 className="my-2 text-2xl font-bold">
+          Password and Security Settings
+        </h2>
+        <p className="mb-10 text-sm">
+          Manage your account security and login settings
+        </p>
+
+        <div className="rounded-lg bg-background px-5 py-5">
+          <PasswordForm />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PasswordAndSecurity

--- a/app/password-and-security/page.tsx
+++ b/app/password-and-security/page.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import { PasswordForm } from '~/components/password-and-security/password-form'
+import { Toaster } from '~/components/ui/sonner'
 
 function PasswordAndSecurity() {
   return (
     <div className="h-screen">
-      <div className="m-auto w-2/3 pt-10">
+      <div className="m-auto w-2/3 pt-10 xl:w-1/2">
         <h2 className="my-2 text-2xl font-bold">
           Password and Security Settings
         </h2>
@@ -17,6 +18,7 @@ function PasswordAndSecurity() {
           <PasswordForm />
         </div>
       </div>
+      <Toaster />
     </div>
   )
 }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.468.0",
     "next": "15.1.0",
+    "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.1",
+    "sonner": "^1.7.1",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.24.1"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "preinstall": "npx only-allow pnpm"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.1",
+    "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -19,8 +21,10 @@
     "next": "15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.54.1",
     "tailwind-merge": "^2.5.5",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       next:
         specifier: 15.1.0
         version: 15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next-themes:
+        specifier: ^0.4.4
+        version: 0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -38,6 +41,9 @@ importers:
       react-hook-form:
         specifier: ^7.54.1
         version: 7.54.1(react@19.0.0)
+      sonner:
+        specifier: ^1.7.1
+        version: 1.7.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.5.5
@@ -1602,6 +1608,12 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-themes@0.4.4:
+    resolution: {integrity: sha512-LDQ2qIOJF0VnuVrrMSMLrWGjRMkq+0mpgl6e0juCLqdJ+oo8Q84JRWT6Wh11VDQKkMMe+dVzDKLWs5n87T+PkQ==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
   next@15.1.0:
     resolution: {integrity: sha512-QKhzt6Y8rgLNlj30izdMbxAwjHMFANnLwDwZ+WQh5sMhyt4lEBqDK9QpvWHtIM4rINKPoJ8aiRZKg5ULSybVHw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
@@ -2016,6 +2028,12 @@ packages:
   slice-ansi@7.1.0:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
     engines: {node: '>=18'}
+
+  sonner@1.7.1:
+    resolution: {integrity: sha512-b6LHBfH32SoVasRFECrdY8p8s7hXPDn3OHUFbZZbiB1ctLS9Gdh6rpX2dVrpQA0kiL5jcRzDDldwwLkSKk3+QQ==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -3934,6 +3952,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  next-themes@0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+
   next@15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@next/env': 15.1.0
@@ -4326,6 +4349,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
+
+  sonner@1.7.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   source-map-js@1.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^3.9.1
+        version: 3.9.1(react-hook-form@7.54.1(react@19.0.0))
+      '@radix-ui/react-label':
+        specifier: ^2.1.1
+        version: 2.1.1(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-slot':
         specifier: ^1.1.1
         version: 1.1.1(@types/react@19.0.1)(react@19.0.0)
@@ -29,12 +35,18 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      react-hook-form:
+        specifier: ^7.54.1
+        version: 7.54.1(react@19.0.0)
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.5.5
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.16)
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.1
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.6.0
@@ -204,6 +216,11 @@ packages:
   '@eslint/plugin-kit@0.2.4':
     resolution: {integrity: sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@hookform/resolvers@3.9.1':
+    resolution: {integrity: sha512-ud2HqmGBM0P0IABqoskKWI6PEf6ZDDBZkFqe2Vnl+mTHCEHzr3ISjjZyCwTjC/qpL25JC9aIDkloQejvMeq0ug==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -433,6 +450,32 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-label@2.1.1':
+    resolution: {integrity: sha512-UUw5E4e/2+4kFMH7+YxORXGWggtY6sM8WIwh5RZchhLuUg2H1hc98Py+pr8HMz6rdaYrK2t296ZEjYLOCO5uUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.0.1':
+    resolution: {integrity: sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-slot@1.1.1':
@@ -1834,6 +1877,12 @@ packages:
     peerDependencies:
       react: ^19.0.0
 
+  react-hook-form@7.54.1:
+    resolution: {integrity: sha512-PUNzFwQeQ5oHiiTUO7GO/EJXGEtuun2Y1A59rLnZBBj+vNEOWt/3ERTiG1/zt7dVeJEM+4vDX/7XQ/qanuvPMg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -2224,6 +2273,9 @@ packages:
     resolution: {integrity: sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==}
     engines: {node: '>=12.20'}
 
+  zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -2392,6 +2444,10 @@ snapshots:
     dependencies:
       levn: 0.4.1
 
+  '@hookform/resolvers@3.9.1(react-hook-form@7.54.1(react@19.0.0))':
+    dependencies:
+      react-hook-form: 7.54.1(react@19.0.0)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -2558,6 +2614,24 @@ snapshots:
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.1
+
+  '@radix-ui/react-label@2.1.1(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.1
+      '@types/react-dom': 19.0.2(@types/react@19.0.1)
+
+  '@radix-ui/react-primitive@2.0.1(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.1(@types/react@19.0.1)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.1
+      '@types/react-dom': 19.0.2(@types/react@19.0.1)
 
   '@radix-ui/react-slot@1.1.1(@types/react@19.0.1)(react@19.0.0)':
     dependencies:
@@ -4070,6 +4144,10 @@ snapshots:
       react: 19.0.0
       scheduler: 0.25.0
 
+  react-hook-form@7.54.1(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+
   react-is@16.13.1: {}
 
   react@19.0.0: {}
@@ -4567,3 +4645,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.1.1: {}
+
+  zod@3.24.1: {}

--- a/src/components/password-and-security/password-form-field.tsx
+++ b/src/components/password-and-security/password-form-field.tsx
@@ -11,7 +11,7 @@ import { Input } from '~/components/ui/input'
 import { Control } from 'react-hook-form'
 import { FormDataType } from './password-form'
 
-interface FormProps {
+type FormProps = {
   control: Control<FormDataType>
   name: keyof FormDataType
   label: string

--- a/src/components/password-and-security/password-form-field.tsx
+++ b/src/components/password-and-security/password-form-field.tsx
@@ -8,11 +8,12 @@ import {
 } from '~/components/ui/form'
 
 import { Input } from '~/components/ui/input'
-import { Control, FieldValues } from 'react-hook-form'
+import { Control } from 'react-hook-form'
+import { FormDataType } from './password-form'
 
 interface FormProps {
-  control: Control<FieldValues>
-  name: string
+  control: Control<FormDataType>
+  name: keyof FormDataType
   label: string
   type: string
 }

--- a/src/components/password-and-security/password-form-field.tsx
+++ b/src/components/password-and-security/password-form-field.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+} from '~/components/ui/form'
+
+import { Input } from '~/components/ui/input'
+import { Control, FieldValues } from 'react-hook-form'
+
+interface FormProps {
+  control: Control<FieldValues>
+  name: string
+  label: string
+  type: string
+}
+
+function PasswordFormField({ control, name, label, type }: FormProps) {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>{label}</FormLabel>
+          <FormControl>
+            <Input type={type} {...field} />
+          </FormControl>
+        </FormItem>
+      )}
+    />
+  )
+}
+
+export { PasswordFormField }

--- a/src/components/password-and-security/password-form-field.tsx
+++ b/src/components/password-and-security/password-form-field.tsx
@@ -1,15 +1,15 @@
 'use client'
 
+import { Control } from 'react-hook-form'
+
 import {
   FormField,
   FormItem,
   FormLabel,
   FormControl,
 } from '~/components/ui/form'
-
 import { Input } from '~/components/ui/input'
-import { Control } from 'react-hook-form'
-import { FormDataType } from './password-form'
+import { FormDataType } from '~/components/password-and-security/password-form'
 
 type FormProps = {
   control: Control<FormDataType>

--- a/src/components/password-and-security/password-form-field.tsx
+++ b/src/components/password-and-security/password-form-field.tsx
@@ -9,7 +9,7 @@ import {
   FormControl,
 } from '~/components/ui/form'
 import { Input } from '~/components/ui/input'
-import { FormDataType } from '~/components/password-and-security/password-form'
+import type { FormDataType } from '~/components/password-and-security/password-form'
 
 type FormProps = {
   control: Control<FormDataType>

--- a/src/components/password-and-security/password-form.tsx
+++ b/src/components/password-and-security/password-form.tsx
@@ -5,8 +5,20 @@ import { Button } from '~/components/ui/button'
 import { Form } from '~/components/ui/form'
 import { PasswordFormField } from '~/components/password-and-security/password-form-field'
 
+export interface FormDataType {
+  currentPassword: string
+  newPassword: string
+  newPasswordConfirm: string
+}
+
 function PasswordForm() {
-  const form = useForm()
+  const form = useForm<FormDataType>({
+    defaultValues: {
+      currentPassword: '',
+      newPassword: '',
+      newPasswordConfirm: '',
+    },
+  })
 
   return (
     <Form {...form}>

--- a/src/components/password-and-security/password-form.tsx
+++ b/src/components/password-and-security/password-form.tsx
@@ -5,7 +5,7 @@ import { Button } from '~/components/ui/button'
 import { Form } from '~/components/ui/form'
 import { PasswordFormField } from '~/components/password-and-security/password-form-field'
 
-export interface FormDataType {
+export type FormDataType = {
   currentPassword: string
   newPassword: string
   newPasswordConfirm: string

--- a/src/components/password-and-security/password-form.tsx
+++ b/src/components/password-and-security/password-form.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form'
 import { Button } from '~/components/ui/button'
 import { Form } from '~/components/ui/form'
 import { PasswordFormField } from '~/components/password-and-security/password-form-field'
+import { toast } from 'sonner'
 
 export type FormDataType = {
   currentPassword: string
@@ -20,10 +21,16 @@ function PasswordForm() {
     },
   })
 
+  const updatePassword = (data: FormDataType): void => {
+    toast.success('비밀번호가 변경되었습니다.')
+    console.log(data)
+    form.reset()
+  }
+
   return (
     <Form {...form}>
       <p className="mb-5 text-xl font-bold">Change Password</p>
-      <form className="space-y-8">
+      <form onSubmit={form.handleSubmit(updatePassword)} className="space-y-8">
         <PasswordFormField
           control={form.control}
           name="currentPassword"
@@ -44,7 +51,7 @@ function PasswordForm() {
           label="Confirm New Password"
           type="password"
         />
-        <Button type="button">Update Password</Button>
+        <Button type="submit">Update Password</Button>
       </form>
     </Form>
   )

--- a/src/components/password-and-security/password-form.tsx
+++ b/src/components/password-and-security/password-form.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useForm } from 'react-hook-form'
+import { Button } from '~/components/ui/button'
+import { Form } from '~/components/ui/form'
+import { PasswordFormField } from '~/components/password-and-security/password-form-field'
+
+function PasswordForm() {
+  const form = useForm()
+
+  return (
+    <Form {...form}>
+      <p className="mb-5 text-xl font-bold">Change Password</p>
+      <form className="space-y-8">
+        <PasswordFormField
+          control={form.control}
+          name="currentPassword"
+          label="Current Password"
+          type="password"
+        />
+
+        <PasswordFormField
+          control={form.control}
+          name="newPassword"
+          label="New Password"
+          type="password"
+        />
+
+        <PasswordFormField
+          control={form.control}
+          name="newPasswordConfirm"
+          label="Confirm New Password"
+          type="password"
+        />
+        <Button type="button">Update Password</Button>
+      </form>
+    </Form>
+  )
+}
+
+export { PasswordForm }

--- a/src/components/password-and-security/password-form.tsx
+++ b/src/components/password-and-security/password-form.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+
 import { Button } from '~/components/ui/button'
 import { Form } from '~/components/ui/form'
 import { PasswordFormField } from '~/components/password-and-security/password-form-field'
-import { toast } from 'sonner'
 
 export type FormDataType = {
   currentPassword: string

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,176 @@
+import * as React from 'react'
+import * as LabelPrimitive from '@radix-ui/react-label'
+import { Slot } from '@radix-ui/react-slot'
+import {
+  Controller,
+  ControllerProps,
+  FieldPath,
+  FieldValues,
+  FormProvider,
+  useFormContext,
+} from 'react-hook-form'
+
+import { cn } from '~/utils/cn'
+import { Label } from '~/components/ui/label'
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue,
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState, formState } = useFormContext()
+
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error('useFormField should be used within <FormField>')
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue,
+)
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div ref={ref} className={cn('space-y-2', className)} {...props} />
+    </FormItemContext.Provider>
+  )
+})
+FormItem.displayName = 'FormItem'
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && 'text-destructive', className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+})
+FormLabel.displayName = 'FormLabel'
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+})
+FormControl.displayName = 'FormControl'
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn('text-[0.8rem] text-muted-foreground', className)}
+      {...props}
+    />
+  )
+})
+FormDescription.displayName = 'FormDescription'
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message) : children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn('text-[0.8rem] font-medium text-destructive', className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+})
+FormMessage.displayName = 'FormMessage'
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+
+import { cn } from '~/utils/cn'
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  },
+)
+Input.displayName = 'Input'
+
+export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import * as React from 'react'
+import * as LabelPrimitive from '@radix-ui/react-label'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '~/utils/cn'
+
+const labelVariants = cva(
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,29 @@
+import { useTheme } from 'next-themes'
+import { Toaster as Sonner } from 'sonner'
+
+type ToasterProps = React.ComponentProps<typeof Sonner>
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = 'system' } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps['theme']}
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+          description: 'group-[.toast]:text-muted-foreground',
+          actionButton:
+            'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
+          cancelButton:
+            'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }


### PR DESCRIPTION
## 📌 관련 이슈
> - #12 

## 📑 작업 내용
- Password and Security 페이지의 UI를 구현한다.
- Update password 버튼을 누르면 상호작용한다.
  - 비밀번호가 변경되었다는 알림창이 뜬다.
  - 입력한 데이터가 콘솔에 출력되고 input의 값들이 초기화된다.

## 🖥️ (Optional) 참고자료
<img width="1277" alt="스크린샷 2024-12-17 오전 11 47 36" src="https://github.com/user-attachments/assets/2c661a72-512a-4413-a9de-0d30a33a206e" />

<img width="1624" alt="스크린샷 2024-12-17 오후 5 03 39" src="https://github.com/user-attachments/assets/75098290-b6de-4b49-91f1-9033fca71f90" />

