### PR TITLE
feat: Notify 페이지 UI 구현

### DIFF
--- a/app/notify/page.tsx
+++ b/app/notify/page.tsx
@@ -1,0 +1,12 @@
+import { NotifyGroup } from '~/components/notify/notify-group'
+
+function NotifyPage() {
+  return (
+    <div className="mb-28 mt-4">
+      <NotifyGroup />
+      <NotifyGroup />
+    </div>
+  )
+}
+
+export default NotifyPage

--- a/src/components/notify/notify-group.tsx
+++ b/src/components/notify/notify-group.tsx
@@ -1,0 +1,16 @@
+import { NotifyItem } from '~/components/notify/notify-item'
+
+function NotifyGroup() {
+  return (
+    <div className="mx-auto max-w-xl px-4 pt-5">
+      <p className="font-bold text-muted-foreground">Today</p>
+      <div>
+        <NotifyItem />
+        <NotifyItem />
+        <NotifyItem />
+      </div>
+    </div>
+  )
+}
+
+export { NotifyGroup }

--- a/src/components/notify/notify-group.tsx
+++ b/src/components/notify/notify-group.tsx
@@ -1,10 +1,12 @@
 import { NotifyItem } from '~/components/notify/notify-item'
 
 function NotifyGroup() {
+  // 알림 발생 날짜에 맞게 묶어서 출력하기 위한 컴포넌트
   return (
     <div className="mx-auto max-w-xl px-4 pt-5">
       <p className="font-bold text-muted-foreground">Today</p>
       <div>
+        {/* 데이터를 map으로 출력할 예정*/}
         <NotifyItem />
         <NotifyItem />
         <NotifyItem />

--- a/src/components/notify/notify-item.tsx
+++ b/src/components/notify/notify-item.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+
+import { CircleUserRound } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert'
+
+function NotifyItem() {
+  return (
+    <Link href="/">
+      <Alert className="my-4 flex justify-between p-4">
+        <div className="flex items-center gap-3">
+          <div>
+            <CircleUserRound className="h-12 w-12" />
+          </div>
+          <div>
+            <AlertTitle className="text-base font-semibold">
+              Alex Morgan
+            </AlertTitle>
+            <AlertDescription className="text-sm text-muted-foreground">
+              like your post
+            </AlertDescription>
+          </div>
+        </div>
+        <div className="text-xs text-muted-foreground">2024.12.18</div>
+      </Alert>
+    </Link>
+  )
+}
+
+export { NotifyItem }

--- a/src/components/notify/notify-item.tsx
+++ b/src/components/notify/notify-item.tsx
@@ -4,6 +4,7 @@ import { CircleUserRound } from 'lucide-react'
 import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert'
 
 function NotifyItem() {
+  // 데이터를 props로 받아 출력
   return (
     <Link href="/">
       <Alert className="my-4 flex justify-between p-4">
@@ -13,14 +14,16 @@ function NotifyItem() {
           </div>
           <div>
             <AlertTitle className="text-base font-semibold">
-              Alex Morgan
+              Alex Morgan {/*이름*/}
             </AlertTitle>
             <AlertDescription className="text-sm text-muted-foreground">
-              like your post
+              like your post {/*액션*/}
             </AlertDescription>
           </div>
         </div>
-        <div className="text-xs text-muted-foreground">2024.12.18</div>
+        <div className="text-xs text-muted-foreground">
+          2024.12.18 {/*날짜*/}
+        </div>
       </Alert>
     </Link>
   )

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '~/utils/cn'
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7',
+  {
+    variants: {
+      variant: {
+        default: 'bg-background text-foreground',
+        destructive:
+          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = 'Alert'
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn('mb-1 font-medium leading-none tracking-tight', className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = 'AlertTitle'
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('text-sm [&_p]:leading-relaxed', className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = 'AlertDescription'
+
+export { Alert, AlertTitle, AlertDescription }


### PR DESCRIPTION
## 📌 관련 이슈
> - #14

## 📑 작업 내용
- Notify 페이지 UI를 구현한다.
- **NotifyPage**: 알림들을 출력하는 페이지
- **NotifyGroup**: 알림을 기간별로 그룹화하기 위한 컴포넌트
- **NotifyItem**: 알림 UI, 누르면 해당 포스트로 이동하도록 구현할 예정

## 🖥️ (Optional) 참고자료
<img width="338" alt="스크린샷 2024-12-18 오후 1 41 55" src="https://github.com/user-attachments/assets/6e46a828-3403-4180-b570-48f2760ccafc" />
