### PR TITLE
feat: notification drawer UI 구현

### DIFF
--- a/app/notify/page.tsx
+++ b/app/notify/page.tsx
@@ -1,10 +1,14 @@
+import { SiteHeader } from '~/components/common/site-header'
 import { NotifyGroup } from '~/components/notify/notify-group'
 
 function NotifyPage() {
   return (
-    <div className="mb-28 mt-4">
-      <NotifyGroup />
-      <NotifyGroup />
+    <div className="h-screen bg-gray-100">
+      <SiteHeader />
+      <div className="mb-28 mt-4">
+        <NotifyGroup />
+        <NotifyGroup />
+      </div>
     </div>
   )
 }

--- a/app/notify/page.tsx
+++ b/app/notify/page.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useState } from 'react'
+
 import { SiteHeader } from '~/components/common/site-header'
 import { NotifyGroup } from '~/components/notify/notify-group'
 
@@ -37,8 +39,17 @@ const mockData: MockDataType[] = [
 ]
 
 function NotifyPage() {
+  const [data, setData] = useState(mockData)
+
+  const updateIsRead = (id: number) => {
+    const newData = data.map((item) =>
+      item.id === id ? { ...item, isRead: true } : item,
+    )
+    setData(newData)
+  }
+
   // 날짜별로 그룹화한 데이터
-  const groupedData = mockData.reduce<GroupedMockData>((acc, curr) => {
+  const groupedData = data.reduce<GroupedMockData>((acc, curr) => {
     const { createdAt } = curr
 
     if (!acc[createdAt]) {
@@ -53,7 +64,12 @@ function NotifyPage() {
       <SiteHeader />
       <div className="mb-28 mt-4">
         {Object.entries(groupedData).map(([createdAt, items]) => (
-          <NotifyGroup key={createdAt} date={createdAt} items={items} />
+          <NotifyGroup
+            key={createdAt}
+            date={createdAt}
+            items={items}
+            updateIsRead={updateIsRead}
+          />
         ))}
       </div>
     </div>

--- a/app/notify/page.tsx
+++ b/app/notify/page.tsx
@@ -1,13 +1,60 @@
+'use client'
+
 import { SiteHeader } from '~/components/common/site-header'
 import { NotifyGroup } from '~/components/notify/notify-group'
 
+import type { MockDataType, GroupedMockData } from '~/types/mockdata'
+
+const mockData: MockDataType[] = [
+  {
+    id: 1,
+    userId: 'wontory',
+    action: '님이 게시글에 좋아요를 눌렀습니다.',
+    createdAt: '2024.12.20',
+    isRead: false,
+  },
+  {
+    id: 2,
+    userId: 'jyooni99',
+    action: '님이 회원님을 팔로우하기 시작했습니다.',
+    createdAt: '2024.12.20',
+    isRead: false,
+  },
+  {
+    id: 3,
+    userId: 'E0min',
+    action: '님이 회원님의 게시글에 댓글을 남겼습니다.',
+    createdAt: '2024.12.19',
+    isRead: false,
+  },
+  {
+    id: 4,
+    userId: 'yujsoo',
+    action: '님이 회원님의 게시글에 좋아요를 눌렀습니다.',
+    createdAt: '2024.12.19',
+    isRead: false,
+  },
+]
+
 function NotifyPage() {
+  // 날짜별로 그룹화한 데이터
+  const groupedData = mockData.reduce<GroupedMockData>((acc, curr) => {
+    const { createdAt } = curr
+
+    if (!acc[createdAt]) {
+      acc[createdAt] = []
+    }
+    acc[createdAt].push(curr)
+    return acc
+  }, {} as GroupedMockData)
+
   return (
     <div className="h-screen bg-gray-100">
       <SiteHeader />
       <div className="mb-28 mt-4">
-        <NotifyGroup />
-        <NotifyGroup />
+        {Object.entries(groupedData).map(([createdAt, items]) => (
+          <NotifyGroup key={createdAt} date={createdAt} items={items} />
+        ))}
       </div>
     </div>
   )

--- a/src/components/common/notification-button.tsx
+++ b/src/components/common/notification-button.tsx
@@ -3,18 +3,61 @@
 import Link from 'next/link'
 import { Bell } from 'lucide-react'
 
+import { NotifyItem } from '~/components/notify/notify-item'
 import { Button } from '~/components/ui/button'
 import {
   Sheet,
   SheetClose,
   SheetContent,
-  SheetFooter,
-  SheetHeader,
   SheetTitle,
   SheetTrigger,
 } from '~/components/ui/custom-sheet'
 
+import type { MockDataType } from '~/types/mockdata'
+import { useState } from 'react'
+import { SheetDescription } from '../ui/sheet'
+
+const mockData: MockDataType[] = [
+  {
+    id: 1,
+    userId: 'wontory',
+    action: '님이 게시글에 좋아요를 눌렀습니다.',
+    createdAt: '2024.12.20',
+    isRead: false,
+  },
+  {
+    id: 2,
+    userId: 'jyooni99',
+    action: '님이 회원님을 팔로우하기 시작했습니다.',
+    createdAt: '2024.12.20',
+    isRead: false,
+  },
+  {
+    id: 3,
+    userId: 'E0min',
+    action: '님이 회원님의 게시글에 댓글을 남겼습니다.',
+    createdAt: '2024.12.19',
+    isRead: false,
+  },
+  {
+    id: 4,
+    userId: 'yujsoo',
+    action: '님이 회원님의 게시글에 좋아요를 눌렀습니다.',
+    createdAt: '2024.12.19',
+    isRead: false,
+  },
+]
+
 function NotificationButton() {
+  const [data, setData] = useState(mockData)
+
+  const updateIsRead = (id: number) => {
+    const newData = data.map((item) =>
+      item.id === id ? { ...item, isRead: true } : item,
+    )
+    setData(newData)
+  }
+
   return (
     <Sheet>
       <SheetTrigger asChild>
@@ -24,20 +67,23 @@ function NotificationButton() {
         </Button>
       </SheetTrigger>
       <SheetContent>
-        <SheetHeader>
-          <SheetTitle className="flex items-center gap-2">
-            <Bell />
-            Notifications
-          </SheetTitle>
-        </SheetHeader>
-        <div className="my-6" />
-        <SheetFooter>
-          <SheetClose asChild>
-            <Button className="h-12 w-full py-3 text-center" asChild>
-              <Link href="/notify">View All</Link>
-            </Button>
-          </SheetClose>
-        </SheetFooter>
+        <SheetTitle className="flex items-center gap-2">
+          <Bell />
+          Notifications
+        </SheetTitle>
+        <SheetDescription className="opacity-0">
+          View Notifications
+        </SheetDescription>
+        <div>
+          {data.map((item) => (
+            <NotifyItem key={item.id} data={item} updateIsRead={updateIsRead} />
+          ))}
+        </div>
+        <SheetClose asChild>
+          <Button className="h-12 w-full py-3 text-center" asChild>
+            <Link href="/notify">View All</Link>
+          </Button>
+        </SheetClose>
       </SheetContent>
     </Sheet>
   )

--- a/src/components/common/notification-button.tsx
+++ b/src/components/common/notification-button.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import Link from 'next/link'
+import { Bell } from 'lucide-react'
+
+import { NotifyItem } from '~/components/notify/notify-item'
+import { Button } from '~/components/ui/button'
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '~/components/ui/custom-sheet'
+
+function NotificationButton() {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="ghost" className="flex items-center gap-2">
+          <Bell className="h-5 w-5" />
+          Notifications
+        </Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            <Bell />
+            Notifications
+          </SheetTitle>
+        </SheetHeader>
+        <div className="my-6">
+          <NotifyItem />
+          <NotifyItem />
+          <NotifyItem />
+        </div>
+        <SheetFooter>
+          <SheetClose asChild>
+            <Button className="h-12 w-full py-3 text-center" asChild>
+              <Link href="/notify">View All</Link>
+            </Button>
+          </SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+export { NotificationButton }

--- a/src/components/common/notification-button.tsx
+++ b/src/components/common/notification-button.tsx
@@ -3,7 +3,6 @@
 import Link from 'next/link'
 import { Bell } from 'lucide-react'
 
-import { NotifyItem } from '~/components/notify/notify-item'
 import { Button } from '~/components/ui/button'
 import {
   Sheet,
@@ -31,11 +30,7 @@ function NotificationButton() {
             Notifications
           </SheetTitle>
         </SheetHeader>
-        <div className="my-6">
-          <NotifyItem />
-          <NotifyItem />
-          <NotifyItem />
-        </div>
+        <div className="my-6" />
         <SheetFooter>
           <SheetClose asChild>
             <Button className="h-12 w-full py-3 text-center" asChild>

--- a/src/components/common/notification-button.tsx
+++ b/src/components/common/notification-button.tsx
@@ -2,7 +2,9 @@
 
 import Link from 'next/link'
 import { Bell } from 'lucide-react'
+import { useState } from 'react'
 
+import type { MockDataType } from '~/types/mockdata'
 import { NotifyItem } from '~/components/notify/notify-item'
 import { Button } from '~/components/ui/button'
 import {
@@ -11,11 +13,8 @@ import {
   SheetContent,
   SheetTitle,
   SheetTrigger,
+  SheetDescription,
 } from '~/components/ui/custom-sheet'
-
-import type { MockDataType } from '~/types/mockdata'
-import { useState } from 'react'
-import { SheetDescription } from '../ui/sheet'
 
 const mockData: MockDataType[] = [
   {

--- a/src/components/common/site-header.tsx
+++ b/src/components/common/site-header.tsx
@@ -1,8 +1,9 @@
-import { Bell, User } from 'lucide-react'
+import { User } from 'lucide-react'
 import Image from 'next/image'
 
-import { Button } from '~/components/ui/button'
 import Logo from '~/assets/svgs/logo.svg'
+import { Button } from '~/components/ui/button'
+import { NotificationButton } from '~/components/common/notification-button'
 
 function SiteHeader() {
   return (
@@ -19,10 +20,7 @@ function SiteHeader() {
             <User className="h-5 w-5" />
             Profile
           </Button>
-          <Button variant="ghost" className="flex items-center gap-2">
-            <Bell className="h-5 w-5" />
-            Notifications
-          </Button>
+          <NotificationButton />
         </div>
       </div>
     </nav>

--- a/src/components/notify/notify-group.tsx
+++ b/src/components/notify/notify-group.tsx
@@ -1,15 +1,21 @@
 import { NotifyItem } from '~/components/notify/notify-item'
+import type { MockDataType } from '~/types/mockdata'
 
-function NotifyGroup() {
+type NotifyGroupProps = {
+  date: string
+  items: MockDataType[]
+}
+
+function NotifyGroup({ date, items }: NotifyGroupProps) {
+  console.log(items)
   // 알림 발생 날짜에 맞게 묶어서 출력하기 위한 컴포넌트
   return (
     <div className="mx-auto max-w-xl px-4 pt-5">
-      <p className="font-bold text-muted-foreground">Today</p>
+      <p className="font-bold text-muted-foreground">{date}</p>
       <div>
-        {/* 데이터를 map으로 출력할 예정*/}
-        <NotifyItem />
-        <NotifyItem />
-        <NotifyItem />
+        {items.map((item) => (
+          <NotifyItem key={item.id} data={item} />
+        ))}
       </div>
     </div>
   )

--- a/src/components/notify/notify-group.tsx
+++ b/src/components/notify/notify-group.tsx
@@ -8,7 +8,6 @@ type NotifyGroupProps = {
 }
 
 function NotifyGroup({ date, items, updateIsRead }: NotifyGroupProps) {
-  console.log(items)
   // 알림 발생 날짜에 맞게 묶어서 출력하기 위한 컴포넌트
   return (
     <div className="mx-auto max-w-xl px-4 pt-5">

--- a/src/components/notify/notify-group.tsx
+++ b/src/components/notify/notify-group.tsx
@@ -4,9 +4,10 @@ import type { MockDataType } from '~/types/mockdata'
 type NotifyGroupProps = {
   date: string
   items: MockDataType[]
+  updateIsRead: (id: number) => void
 }
 
-function NotifyGroup({ date, items }: NotifyGroupProps) {
+function NotifyGroup({ date, items, updateIsRead }: NotifyGroupProps) {
   console.log(items)
   // 알림 발생 날짜에 맞게 묶어서 출력하기 위한 컴포넌트
   return (
@@ -14,7 +15,7 @@ function NotifyGroup({ date, items }: NotifyGroupProps) {
       <p className="font-bold text-muted-foreground">{date}</p>
       <div>
         {items.map((item) => (
-          <NotifyItem key={item.id} data={item} />
+          <NotifyItem key={item.id} data={item} updateIsRead={updateIsRead} />
         ))}
       </div>
     </div>

--- a/src/components/notify/notify-group.tsx
+++ b/src/components/notify/notify-group.tsx
@@ -1,11 +1,5 @@
 import { NotifyItem } from '~/components/notify/notify-item'
-import type { MockDataType } from '~/types/mockdata'
-
-type NotifyGroupProps = {
-  date: string
-  items: MockDataType[]
-  updateIsRead: (id: number) => void
-}
+import type { NotifyGroupProps } from '~/types/mockdata'
 
 function NotifyGroup({ date, items, updateIsRead }: NotifyGroupProps) {
   // 알림 발생 날짜에 맞게 묶어서 출력하기 위한 컴포넌트

--- a/src/components/notify/notify-item.tsx
+++ b/src/components/notify/notify-item.tsx
@@ -1,31 +1,30 @@
-import Link from 'next/link'
+'use client'
 
-import { CircleUserRound } from 'lucide-react'
 import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert'
+import type { MockDataType } from '~/types/mockdata'
 
-function NotifyItem() {
-  // 데이터를 props로 받아 출력
+type NotifyItemsProp = {
+  data: MockDataType
+}
+
+function NotifyItem({ data }: NotifyItemsProp) {
   return (
-    <Link href="/">
-      <Alert className="my-4 flex justify-between p-4">
-        <div className="flex items-center gap-3">
-          <div>
-            <CircleUserRound className="h-12 w-12" />
-          </div>
-          <div>
-            <AlertTitle className="text-base font-semibold">
-              Alex Morgan {/*이름*/}
-            </AlertTitle>
-            <AlertDescription className="text-sm text-muted-foreground">
-              like your post {/*액션*/}
-            </AlertDescription>
-          </div>
+    <Alert className="relative my-4 flex cursor-pointer justify-between p-4">
+      <div className="items-top flex gap-3">
+        <div>
+          <div className="h-12 w-12 rounded-full bg-gray-300" />
         </div>
-        <div className="text-xs text-muted-foreground">
-          2024.12.18 {/*날짜*/}
+        <div className="px-4">
+          <AlertTitle className="text-base font-semibold">
+            {data.userId}
+            <span className="font-normal"> {data.action}</span>
+          </AlertTitle>
+          <AlertDescription className="text-sm text-muted-foreground">
+            {data.createdAt}
+          </AlertDescription>
         </div>
-      </Alert>
-    </Link>
+      </div>
+    </Alert>
   )
 }
 

--- a/src/components/notify/notify-item.tsx
+++ b/src/components/notify/notify-item.tsx
@@ -18,7 +18,7 @@ function NotifyItem({ data, updateIsRead }: NotifyItemsProp) {
         <div>
           <div className="h-12 w-12 rounded-full bg-gray-300" />
         </div>
-        <div className="px-4">
+        <div className="px-6">
           <AlertTitle className="text-base font-semibold">
             {data.userId}
             <span className="font-normal"> {data.action}</span>
@@ -28,7 +28,9 @@ function NotifyItem({ data, updateIsRead }: NotifyItemsProp) {
           </AlertDescription>
         </div>
       </div>
-      {data.isRead ? null : <div className="h-3 w-3 rounded-full bg-chart-1" />}
+      {data.isRead ? null : (
+        <div className="absolute right-4 h-3 w-3 rounded-full bg-chart-1" />
+      )}
     </Alert>
   )
 }

--- a/src/components/notify/notify-item.tsx
+++ b/src/components/notify/notify-item.tsx
@@ -4,10 +4,12 @@ import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert'
 import type { NotifyItemProp } from '~/types/mockdata'
 
 function NotifyItem({ data, updateIsRead }: NotifyItemProp) {
+  const { id, isRead, userId, action, createdAt } = data
+
   return (
     <Alert
-      onClick={() => updateIsRead(data.id)}
-      className={`relative my-4 flex cursor-pointer justify-between p-4 ${data.isRead ? 'opacity-50' : 'opacity-100'}`}
+      onClick={() => updateIsRead(id)}
+      className={`relative my-4 flex cursor-pointer justify-between p-4 ${isRead ? 'opacity-50' : 'opacity-100'}`}
     >
       <div className="items-top flex gap-3">
         <div>
@@ -15,15 +17,15 @@ function NotifyItem({ data, updateIsRead }: NotifyItemProp) {
         </div>
         <div className="px-6">
           <AlertTitle className="text-base font-semibold">
-            {data.userId}
-            <span className="font-normal"> {data.action}</span>
+            {userId}
+            <span className="font-normal"> {action}</span>
           </AlertTitle>
           <AlertDescription className="text-sm text-muted-foreground">
-            {data.createdAt}
+            {createdAt}
           </AlertDescription>
         </div>
       </div>
-      {data.isRead ? null : (
+      {isRead ? null : (
         <div className="absolute right-4 h-3 w-3 rounded-full bg-chart-1" />
       )}
     </Alert>

--- a/src/components/notify/notify-item.tsx
+++ b/src/components/notify/notify-item.tsx
@@ -5,11 +5,15 @@ import type { MockDataType } from '~/types/mockdata'
 
 type NotifyItemsProp = {
   data: MockDataType
+  updateIsRead: (id: number) => void
 }
 
-function NotifyItem({ data }: NotifyItemsProp) {
+function NotifyItem({ data, updateIsRead }: NotifyItemsProp) {
   return (
-    <Alert className="relative my-4 flex cursor-pointer justify-between p-4">
+    <Alert
+      onClick={() => updateIsRead(data.id)}
+      className={`relative my-4 flex cursor-pointer justify-between p-4 ${data.isRead ? 'opacity-50' : 'opacity-100'}`}
+    >
       <div className="items-top flex gap-3">
         <div>
           <div className="h-12 w-12 rounded-full bg-gray-300" />
@@ -24,6 +28,7 @@ function NotifyItem({ data }: NotifyItemsProp) {
           </AlertDescription>
         </div>
       </div>
+      {data.isRead ? null : <div className="h-3 w-3 rounded-full bg-chart-1" />}
     </Alert>
   )
 }

--- a/src/components/notify/notify-item.tsx
+++ b/src/components/notify/notify-item.tsx
@@ -1,14 +1,9 @@
 'use client'
 
 import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert'
-import type { MockDataType } from '~/types/mockdata'
+import type { NotifyItemProp } from '~/types/mockdata'
 
-type NotifyItemsProp = {
-  data: MockDataType
-  updateIsRead: (id: number) => void
-}
-
-function NotifyItem({ data, updateIsRead }: NotifyItemsProp) {
+function NotifyItem({ data, updateIsRead }: NotifyItemProp) {
   return (
     <Alert
       onClick={() => updateIsRead(data.id)}

--- a/src/components/ui/custom-sheet.tsx
+++ b/src/components/ui/custom-sheet.tsx
@@ -1,0 +1,142 @@
+import * as React from 'react'
+import * as SheetPrimitive from '@radix-ui/react-dialog'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { X } from 'lucide-react'
+
+import { cn } from '~/utils/cn'
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  'fixed z-50 gap-4 bg-background p-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
+  {
+    variants: {
+      side: {
+        top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+        bottom:
+          'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+        left: 'inset-y-0 left-0 h-full w-full border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:w-3/4 sm:max-w-sm',
+        right:
+          'inset-y-0 right-0 h-full w-full border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:w-3/4 sm:max-w-sm',
+      },
+    },
+    defaultVariants: {
+      side: 'right',
+    },
+  },
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = 'right', className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      <SheetPrimitive.Close
+        className="absolute right-4 top-5 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 disabled:pointer-events-none data-[state=open]:bg-secondary"
+        tabIndex={-1}
+      >
+        <X className="h-5 w-5" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col space-y-2 text-center sm:text-left',
+      className,
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = 'SheetHeader'
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className,
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = 'SheetFooter'
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold text-foreground', className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react'
+import * as SheetPrimitive from '@radix-ui/react-dialog'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { X } from 'lucide-react'
+
+import { cn } from '~/utils/cn'
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
+  {
+    variants: {
+      side: {
+        top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+        bottom:
+          'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+        left: 'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+        right:
+          'inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
+      },
+    },
+    defaultVariants: {
+      side: 'right',
+    },
+  },
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = 'right', className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col space-y-2 text-center sm:text-left',
+      className,
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = 'SheetHeader'
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className,
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = 'SheetFooter'
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold text-foreground', className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/src/types/mockdata.ts
+++ b/src/types/mockdata.ts
@@ -9,3 +9,14 @@ export type MockDataType = {
 export type GroupedMockData = {
   [key: string]: MockDataType[] // 날짜별로 데이터를 그룹화한 객체
 }
+
+export type NotifyGroupProps = {
+  date: string
+  items: MockDataType[]
+  updateIsRead: (id: number) => void
+}
+
+export type NotifyItemProp = {
+  data: MockDataType
+  updateIsRead: (id: number) => void
+}

--- a/src/types/mockdata.ts
+++ b/src/types/mockdata.ts
@@ -1,0 +1,11 @@
+export type MockDataType = {
+  id: number
+  userId: string
+  action: string
+  createdAt: string
+  isRead: boolean
+}
+
+export type GroupedMockData = {
+  [key: string]: MockDataType[] // 날짜별로 데이터를 그룹화한 객체
+}


### PR DESCRIPTION
## 📌 관련 이슈
> - #28 

## 📑 작업 내용
- drawer UI를 구현한다.
- 알림 아이콘 클릭 시 drawer가 표시되도록 로직을 구현한다.
- 알림 아이콘 또는 메뉴 외부를 클릭 할 경우 drawer 메뉴가 사라지도록 로직을 구현한다.
- View All을 클릭하면 Notify 페이지로 이동하는 로직을 구현한다.

## 🖥️ (Optional) 참고자료
<img width="1330" alt="스크린샷 2024-12-22 오후 7 43 14" src="https://github.com/user-attachments/assets/ff9e70ec-575a-4961-a189-6b3787150ac7" />

<img width="645" alt="스크린샷 2024-12-22 오후 7 46 31" src="https://github.com/user-attachments/assets/6fca4353-4835-4aa0-81c3-854693307e85" />


## etc
UI 부분만 구현했기 때문에 Notify 페이지와 drawer의 알림 읽음 상태가 동기화 되지 않습니다.
새로고침을 할 경우, 데이터가 초기화 됩니다.
