### PR TITLE
feat: 게시글 추가 기능 구현

### DIFF
--- a/app/@modal/(.)write/page.tsx
+++ b/app/@modal/(.)write/page.tsx
@@ -20,7 +20,7 @@ export default function WriteModal() {
 
   return (
     <Dialog open onOpenChange={handleClose}>
-      <DialogContent className="mx-auto mt-20 max-w-lg rounded-lg bg-white p-6 shadow-lg">
+      <DialogContent className="mx-auto max-h-[85%] max-w-lg overflow-y-scroll rounded-lg bg-white p-6 shadow-lg">
         <DialogHeader>
           <DialogTitle>Create Post with A/B Testing</DialogTitle>
         </DialogHeader>

--- a/src/schema/write.ts
+++ b/src/schema/write.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod'
+
+export const writeSchema = z
+  .object({
+    body: z.string().optional(),
+    type: z.enum(['text', 'image'], undefined).optional(),
+    textA: z.string().optional(),
+    textB: z.string().optional(),
+    imageA: z.instanceof(File).optional(),
+    imageB: z.instanceof(File).optional(),
+  })
+  .superRefine((data, ctx) => {
+    // type이 없는 경우, body 필수
+    if (!data.type && !((data.body?.trim().length ?? 0) > 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'If you do not choose a survey option type, you must write the text',
+        path: ['body'],
+      })
+    }
+
+    // type이 text일 때 textA와 textB 필수
+    if (data.type === 'text') {
+      if (!((data.textA?.trim().length ?? 0) > 0)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'textA is required when type is "text"',
+          path: ['textA'],
+        })
+      }
+      if (!((data.textB?.trim().length ?? 0) > 0)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'textB is required when type is "text"',
+          path: ['textB'],
+        })
+      }
+    }
+
+    // type이 image -> imageA, imageB 필수
+    if (data.type === 'image') {
+      if (!data.imageA) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'imageA is required when type is "image"',
+          path: ['imageA'],
+        })
+      }
+      if (!data.imageB) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'imageB is required when type is "image"',
+          path: ['imageB'],
+        })
+      }
+    }
+  })
+
+export type WritePayload = z.infer<typeof writeSchema>

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -56,8 +56,8 @@ export type Database = {
           id: number
           post_id: number
           updated_at: string
-          variant_a_url: string
-          variant_b_url: string
+          variant_a_url: string | null
+          variant_b_url: string | null
         }
         Insert: {
           created_at?: string
@@ -66,8 +66,8 @@ export type Database = {
           id?: number
           post_id: number
           updated_at?: string
-          variant_a_url: string
-          variant_b_url: string
+          variant_a_url?: string | null
+          variant_b_url?: string | null
         }
         Update: {
           created_at?: string
@@ -76,8 +76,8 @@ export type Database = {
           id?: number
           post_id?: number
           updated_at?: string
-          variant_a_url?: string
-          variant_b_url?: string
+          variant_a_url?: string | null
+          variant_b_url?: string | null
         }
         Relationships: [
           {
@@ -291,7 +291,7 @@ export type Database = {
           caption: string | null
           created_at: string
           id: number
-          image_url: string
+          image_url: string | null
           updated_at: string
           user_id: string
         }
@@ -299,7 +299,7 @@ export type Database = {
           caption?: string | null
           created_at?: string
           id?: number
-          image_url: string
+          image_url?: string | null
           updated_at?: string
           user_id: string
         }
@@ -307,7 +307,7 @@ export type Database = {
           caption?: string | null
           created_at?: string
           id?: number
-          image_url?: string
+          image_url?: string | null
           updated_at?: string
           user_id?: string
         }


### PR DESCRIPTION
## 📌 관련 이슈

> - #59 

## 📑 작업 내용

- 포스트를 추가하는 기능을 구현합니다.
  - type- undefined (default): 일반 포스트가 올라갑니다. (첫 번째 필드 입력 필수)
  - type - text : 텍스트 형식의 A/B 테스트가 올라갑니다. (A/B 테스트 텍스트 입력 필수)
  - type - image:  이미지 형식의 A/B 테스트가 올라갑니다. (A/B 테스트 이미지 입력 필수)
 
- 에러메시지 전달을 위해 zod에 조건문을 추가하였습니다 -> 너무 길어져 schema로 이동 
- 서버 / 클라이언트로 나누는 작업은 시간상 리팩토링 기간에 진행할 예정입니다...

## 🖥️ (Optional) 참고자료

[ type - undefined & type - text ]
`type - undefined`: 두 번째 사진에서  `caption: '포스트만 올립니다'` 를 봐주시면 됩니다!
`type - text`: 첫 번째 사진과 두 번째 사진에서 회색 하이라이트가 들어간 부분을 봐주시면 됩니다!

- DB

<img width="1879" alt="스크린샷 2025-01-12 오후 1 58 35" src="https://github.com/user-attachments/assets/1dafad93-5b1e-4b30-8176-ffac44f66c4a" />

<img width="1879" alt="스크린샷 2025-01-12 오후 1 56 21" src="https://github.com/user-attachments/assets/ef74b37b-1773-400b-9553-f2a9960f9721" />



[type - image]

- Storage
<img width="1879" alt="스크린샷 2025-01-12 오후 1 51 34" src="https://github.com/user-attachments/assets/e023057b-e6e7-4bbb-988d-2849b100861a" />

- DB
<img width="1879" alt="스크린샷 2025-01-12 오후 1 51 41" src="https://github.com/user-attachments/assets/74b3b564-151e-43fa-859c-64ceaf3baa02" />


- DB에 저장된 링크로 이동
<img width="1879" alt="스크린샷 2025-01-12 오후 1 51 18" src="https://github.com/user-attachments/assets/87f5f437-c7fe-4fc6-a9ff-c798da50d03f" />

