### PR TITLE
feat: 댓글 및 대댓글 실시간 반영

### DIFF
--- a/app/api/survey-detail/[id]/route.ts
+++ b/app/api/survey-detail/[id]/route.ts
@@ -104,6 +104,8 @@ export async function GET(
       .eq('post_id', postId)
     if (commentsError) throw new Error(commentsError.message)
 
+    const commentsCount = data ? data.length : 0
+
     const comments = data.map(({ users, ...comment }) => ({
       username: users.username,
       ...comment,
@@ -171,7 +173,7 @@ export async function GET(
       votesA,
       votesB,
       userLiked,
-      commentsCount: comments.length,
+      commentsCount,
       userVote,
       voteComplete,
       initLikeCount,

--- a/app/api/survey-detail/[id]/route.ts
+++ b/app/api/survey-detail/[id]/route.ts
@@ -49,6 +49,15 @@ export async function GET(
       .single()
     if (userError) throw new Error(userError.message)
 
+    // UserName 데이터 -> 현재 접속중인 사용자의 이름을 반환
+    const { data: currentUserName, error: currentUserNameError } =
+      await supabase
+        .from('users')
+        .select('username')
+        .eq('id', currentUserId || 'undefined')
+        .single()
+    if (currentUserNameError) throw new Error(currentUserNameError.message)
+
     // UserLiked 여부
     const { data: userLikedData } = await supabase
       .from('likes')
@@ -168,6 +177,7 @@ export async function GET(
       initLikeCount,
       comments: roots,
       currentUserId,
+      currentUserName,
     })
   } catch (error) {
     console.error('Unexpected Error:', error)

--- a/app/survey-detail/[id]/page.tsx
+++ b/app/survey-detail/[id]/page.tsx
@@ -13,6 +13,7 @@ import { Skeleton } from '~/components/ui/skeleton'
 import { SurveyCardSkeleton } from '~/components/common/surveycard-skeleton'
 
 function SurveyDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const [userId, setUserId] = useState<string>()
   const [postData, setPostData] = useState<SurveyCardProps>()
   const [comments, setComments] = useState<Comment[]>()
   const [loading, setLoading] = useState(true)
@@ -57,6 +58,7 @@ function SurveyDetailPage({ params }: { params: Promise<{ id: string }> }) {
           voteComplete: data.voteComplete,
         })
         setComments(data.comments)
+        setUserId(data.currentUserId)
 
         setError(null) // 에러 초기화
       } catch (err) {
@@ -239,7 +241,7 @@ function SurveyDetailPage({ params }: { params: Promise<{ id: string }> }) {
                   <SurveyComment
                     key={comment.id}
                     comment={comment}
-                    currentUserId={postData.userId}
+                    currentUserId={userId}
                     postId={postData.postId}
                     handleCommentLikeToggle={handleCommentLikeToggle}
                   />

--- a/app/survey-detail/[id]/page.tsx
+++ b/app/survey-detail/[id]/page.tsx
@@ -238,7 +238,7 @@ function SurveyDetailPage({ params }: { params: Promise<{ id: string }> }) {
           />
           <Card className="mt-6">
             <CardHeader>
-              <CardTitle>Comments ({comments?.length})</CardTitle>
+              <CardTitle>Comments ({postData.commentsCount})</CardTitle>
             </CardHeader>
             <CardContent>
               {comments ? (

--- a/app/survey-detail/[id]/page.tsx
+++ b/app/survey-detail/[id]/page.tsx
@@ -241,7 +241,7 @@ function SurveyDetailPage({ params }: { params: Promise<{ id: string }> }) {
               <CardTitle>Comments ({postData.commentsCount})</CardTitle>
             </CardHeader>
             <CardContent>
-              {comments ? (
+              {comments.length > 0 ? (
                 comments.map((comment) => (
                   <SurveyComment
                     key={comment.id}
@@ -253,7 +253,7 @@ function SurveyDetailPage({ params }: { params: Promise<{ id: string }> }) {
                   />
                 ))
               ) : (
-                <div>
+                <div className="flex items-center rounded-lg bg-gray-50 p-4 py-4 text-gray-600">
                   <p>Noting Comments</p>
                 </div>
               )}

--- a/app/survey-detail/[id]/page.tsx
+++ b/app/survey-detail/[id]/page.tsx
@@ -13,9 +13,9 @@ import { Skeleton } from '~/components/ui/skeleton'
 import { SurveyCardSkeleton } from '~/components/common/surveycard-skeleton'
 
 function SurveyDetailPage({ params }: { params: Promise<{ id: string }> }) {
-  const [userId, setUserId] = useState<string>()
+  const [userInfo, setUserInfo] = useState({ userId: '', userName: '' })
   const [postData, setPostData] = useState<SurveyCardProps>()
-  const [comments, setComments] = useState<Comment[]>()
+  const [comments, setComments] = useState<Comment[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -58,7 +58,10 @@ function SurveyDetailPage({ params }: { params: Promise<{ id: string }> }) {
           voteComplete: data.voteComplete,
         })
         setComments(data.comments)
-        setUserId(data.currentUserId)
+        setUserInfo({
+          userId: data.currentUserId,
+          userName: data.currentUserName.username,
+        })
 
         setError(null) // 에러 초기화
       } catch (err) {
@@ -241,8 +244,9 @@ function SurveyDetailPage({ params }: { params: Promise<{ id: string }> }) {
                   <SurveyComment
                     key={comment.id}
                     comment={comment}
-                    currentUserId={userId}
+                    currentUserId={userInfo.userId}
                     postId={postData.postId}
+                    setComments={setComments}
                     handleCommentLikeToggle={handleCommentLikeToggle}
                   />
                 ))
@@ -251,7 +255,11 @@ function SurveyDetailPage({ params }: { params: Promise<{ id: string }> }) {
                   <p>Noting Comments</p>
                 </div>
               )}
-              <SurveyCommentInput postId={postData.postId} />
+              <SurveyCommentInput
+                postId={postData.postId}
+                setComments={setComments}
+                currentUserName={userInfo.userName}
+              />
             </CardContent>
           </Card>
         </div>

--- a/src/components/common/survey-card.tsx
+++ b/src/components/common/survey-card.tsx
@@ -1,22 +1,23 @@
-// src/components/common/survey-card.tsx
 'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useState, useEffect } from 'react'
+import { Heart, MessageSquare, Share2, Ellipsis } from 'lucide-react'
+
 import { Card } from '~/components/ui/card'
 import { Progress } from '~/components/ui/progress'
-import { formatLikeCount } from '~/utils/like-formatters'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '~/components/ui/dropdown-menu'
-import { Heart, MessageSquare, Share2, Ellipsis } from 'lucide-react'
-import Image from 'next/image'
-import { useState, useEffect } from 'react'
-import Link from 'next/link'
-import { Tables } from '~/types/supabase'
+import { formatLikeCount } from '~/utils/like-formatters'
 import { createClient } from '~/utils/supabase/client'
 import defaultProfile from '~/assets/svgs/default-profile.svg'
-import { useRouter } from 'next/navigation'
+import { Tables } from '~/types/supabase'
 
 export type SurveyCardProps = {
   post?: Tables<'posts'>
@@ -208,9 +209,9 @@ function SurveyCard({
         </div>
       )}
       <Link href={`/survey-detail/${postId}`} className="block">
-        <p className="mb-4 min-h-20 rounded-lg bg-gray-50 p-4 text-gray-800">
-          {question}
-        </p>
+        <div className="mb-4 flex min-h-20 items-center rounded-lg bg-gray-50 p-4 text-gray-800">
+          <p> {question}</p>
+        </div>
         {post_image_url && (
           <Image
             src={post_image_url}

--- a/src/components/survey-detail/reply-input.tsx
+++ b/src/components/survey-detail/reply-input.tsx
@@ -27,7 +27,7 @@ const replySchema = z.object({
 type ReplyFormValues = z.infer<typeof replySchema>
 
 type ReplyInputProps = {
-  username: string
+  username: string | undefined
   postId: number
   replyId: number | null
   dept: number | null

--- a/src/components/survey-detail/survey-comment-input.tsx
+++ b/src/components/survey-detail/survey-comment-input.tsx
@@ -18,7 +18,6 @@ import {
   FormControl,
   FormMessage,
 } from '~/components/ui/form'
-import { Comment } from '~/types/comment'
 
 // 댓글 입력 스키마 정의
 const commentSchema = z.object({
@@ -32,17 +31,10 @@ type CommentFormValues = z.infer<typeof commentSchema>
 
 type SurveyCommentInputProp = {
   postId: number
-  setComments: React.Dispatch<React.SetStateAction<Comment[]>>
   currentUserName: string
 }
 
-function SurveyCommentInput({
-  postId,
-  setComments,
-  currentUserName,
-}: SurveyCommentInputProp) {
-  console.log('currentUserName:', currentUserName)
-
+function SurveyCommentInput({ postId }: SurveyCommentInputProp) {
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const form = useForm<CommentFormValues>({
@@ -70,17 +62,6 @@ function SurveyCommentInput({
       if (!result.success) throw new Error(result.error)
 
       console.log(result.data)
-
-      // 클라이언트에 추가
-      setComments((prev) => [
-        ...prev,
-        {
-          ...result.data[0],
-          username: currentUserName,
-          likeCount: 0,
-          replies: [],
-        },
-      ])
 
       setTimeout(() => {
         form.reset()

--- a/src/components/survey-detail/survey-comment-input.tsx
+++ b/src/components/survey-detail/survey-comment-input.tsx
@@ -18,6 +18,7 @@ import {
   FormControl,
   FormMessage,
 } from '~/components/ui/form'
+import { Comment } from '~/types/comment'
 
 // 댓글 입력 스키마 정의
 const commentSchema = z.object({
@@ -31,9 +32,17 @@ type CommentFormValues = z.infer<typeof commentSchema>
 
 type SurveyCommentInputProp = {
   postId: number
+  setComments: React.Dispatch<React.SetStateAction<Comment[]>>
+  currentUserName: string
 }
 
-function SurveyCommentInput({ postId }: SurveyCommentInputProp) {
+function SurveyCommentInput({
+  postId,
+  setComments,
+  currentUserName,
+}: SurveyCommentInputProp) {
+  console.log('currentUserName:', currentUserName)
+
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const form = useForm<CommentFormValues>({
@@ -45,6 +54,7 @@ function SurveyCommentInput({ postId }: SurveyCommentInputProp) {
     if (!isSubmitting) {
       setIsSubmitting(true)
 
+      // 서버에 추가
       const response = await fetch('/api/comments/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -59,7 +69,18 @@ function SurveyCommentInput({ postId }: SurveyCommentInputProp) {
       const result = await response.json()
       if (!result.success) throw new Error(result.error)
 
-      console.log(postId, data.comment)
+      console.log(result.data)
+
+      // 클라이언트에 추가
+      setComments((prev) => [
+        ...prev,
+        {
+          ...result.data[0],
+          username: currentUserName,
+          likeCount: 0,
+          replies: [],
+        },
+      ])
 
       setTimeout(() => {
         form.reset()

--- a/src/components/survey-detail/survey-comment.tsx
+++ b/src/components/survey-detail/survey-comment.tsx
@@ -17,17 +17,14 @@ import defaultProfile from '~/assets/svgs/default-profile.svg'
 
 type SurveyCommentProps = {
   comment: Comment
-  postId?: number
   currentUserId?: string
   handleCommentLikeToggle: (id: number) => void
-  setComments: React.Dispatch<React.SetStateAction<Comment[]>>
 }
 
 function SurveyComment({
   comment,
   currentUserId,
   handleCommentLikeToggle,
-  setComments,
 }: SurveyCommentProps) {
   const {
     id,
@@ -51,6 +48,8 @@ function SurveyComment({
 
   // 댓글을 단 유저랑 현재 로그인 한 유저가 같은가? 다르면 수정 및 삭제 불가
   const isAuthorized = () => {
+    console.log(`currentId: ${currentUserId}`)
+    console.log(`userId: ${user_id}`)
     if (currentUserId !== user_id) {
       toast.error(
         `You are not allowed to edit or delete other user's comments.`,
@@ -88,12 +87,6 @@ function SurveyComment({
     const result = await response.json()
     if (!result.success) throw new Error(result.error)
 
-    setComments((prev) =>
-      prev.map((comment) =>
-        comment.id === id ? { ...comment, content: editContent } : comment,
-      ),
-    )
-
     setIsEditing(false)
     toast.success('The comment has been successfully updated')
   }
@@ -123,18 +116,6 @@ function SurveyComment({
       })
       const result = await response.json()
       if (!result.success) throw new Error(result.error)
-
-      setComments((prev) =>
-        prev.map((comment) =>
-          comment.id === id
-            ? {
-                ...comment,
-                is_delete: true,
-                content: 'The comment has been deleted',
-              }
-            : comment,
-        ),
-      )
 
       toast.success(`The comment has been successfully deleted.`)
     } catch {
@@ -242,7 +223,6 @@ function SurveyComment({
             <SurveyComment
               comment={reply}
               currentUserId={currentUserId}
-              setComments={setComments}
               handleCommentLikeToggle={handleCommentLikeToggle}
             />
           </div>

--- a/src/components/survey-detail/survey-comment.tsx
+++ b/src/components/survey-detail/survey-comment.tsx
@@ -20,12 +20,14 @@ type SurveyCommentProps = {
   postId?: number
   currentUserId?: string
   handleCommentLikeToggle: (id: number) => void
+  setComments: React.Dispatch<React.SetStateAction<Comment[]>>
 }
 
 function SurveyComment({
   comment,
   currentUserId,
   handleCommentLikeToggle,
+  setComments,
 }: SurveyCommentProps) {
   const {
     id,
@@ -86,6 +88,12 @@ function SurveyComment({
     const result = await response.json()
     if (!result.success) throw new Error(result.error)
 
+    setComments((prev) =>
+      prev.map((comment) =>
+        comment.id === id ? { ...comment, content: editContent } : comment,
+      ),
+    )
+
     setIsEditing(false)
     toast.success('The comment has been successfully updated')
   }
@@ -115,6 +123,19 @@ function SurveyComment({
       })
       const result = await response.json()
       if (!result.success) throw new Error(result.error)
+
+      setComments((prev) =>
+        prev.map((comment) =>
+          comment.id === id
+            ? {
+                ...comment,
+                is_delete: true,
+                content: 'The comment has been deleted',
+              }
+            : comment,
+        ),
+      )
+
       toast.success(`The comment has been successfully deleted.`)
     } catch {
       toast.error('An error occurred while deleting the comment.')
@@ -221,6 +242,7 @@ function SurveyComment({
             <SurveyComment
               comment={reply}
               currentUserId={currentUserId}
+              setComments={setComments}
               handleCommentLikeToggle={handleCommentLikeToggle}
             />
           </div>

--- a/src/stores/comment-store.ts
+++ b/src/stores/comment-store.ts
@@ -1,0 +1,138 @@
+import { create } from 'zustand'
+import { Comment } from '~/types/comment'
+import { Tables } from '~/types/supabase'
+
+type UserCommentsStoreType = {
+  comments: Comment[]
+  setComments: (comments: Comment[]) => void
+  addComment: (newComment: Tables<'comments'>, currentUserName: string) => void
+  deleteComment: (commentId: number) => void
+  updateComment: (updateComment: Tables<'comments'>) => void
+  toggleLike: (commentId: number, liked: boolean) => void
+}
+
+const useCommentsStore = create<UserCommentsStoreType>((set) => ({
+  comments: [],
+
+  setComments: (comments) => set({ comments }),
+
+  addComment: (newComment, currentUserName) =>
+    set((state) => ({
+      comments: addCommentToTree(state.comments, newComment.parent_id, {
+        ...newComment,
+        username: currentUserName,
+        replies: [],
+        likeCount: 0,
+        userLiked: false,
+      }),
+    })),
+
+  deleteComment: (commentId) =>
+    set((state) => ({
+      comments: removeCommentFromTree(state.comments, commentId),
+    })),
+
+  updateComment: (updatedComment) =>
+    set((state) => {
+      const updatedComments = updateCommentInTree(
+        state.comments,
+        updatedComment,
+      )
+      return { comments: [...updatedComments] } // 새로운 배열로 설정
+    }),
+
+  toggleLike: (commentId, liked) =>
+    set((state) => ({
+      comments: toggleLikeInTree(state.comments, commentId, liked),
+    })),
+}))
+
+// 댓글 트리에 댓글 추가
+const addCommentToTree = (
+  comments: Comment[],
+  parentId: number | null,
+  newReply: Comment,
+): Comment[] => {
+  if (parentId === null) {
+    return [...comments, newReply]
+  }
+
+  return comments.map((comment) => {
+    if (comment.id === parentId) {
+      return {
+        ...comment,
+        replies: [...comment.replies, newReply],
+      }
+    }
+
+    if (comment.replies.length > 0) {
+      return {
+        ...comment,
+        replies: addCommentToTree(comment.replies, parentId, newReply),
+      }
+    }
+
+    return comment
+  })
+}
+
+// 댓글 트리에서 댓글 삭제
+const removeCommentFromTree = (
+  comments: Comment[],
+  commentId: number,
+): Comment[] => {
+  return comments
+    .filter((comment) => comment.id !== commentId)
+    .map((comment) => ({
+      ...comment,
+      replies: removeCommentFromTree(comment.replies, commentId),
+    }))
+}
+
+// 댓글 트리에서 댓글 업데이트
+const updateCommentInTree = (
+  comments: Comment[],
+  updatedComment: Tables<'comments'>,
+): Comment[] => {
+  return comments.map((comment) => {
+    if (comment.id === updatedComment.id) {
+      return { ...comment, ...updatedComment }
+    }
+
+    if (comment.replies.length > 0) {
+      return {
+        ...comment,
+        replies: updateCommentInTree(comment.replies, updatedComment),
+      }
+    }
+
+    return comment
+  })
+}
+
+const toggleLikeInTree = (
+  comments: Comment[],
+  commentId: number,
+  liked: boolean,
+): Comment[] => {
+  return comments.map((comment) => {
+    if (comment.id === commentId) {
+      return {
+        ...comment,
+        userLiked: liked,
+        likeCount: liked ? comment.likeCount + 1 : comment.likeCount - 1,
+      }
+    }
+
+    if (comment.replies.length > 0) {
+      return {
+        ...comment,
+        replies: toggleLikeInTree(comment.replies, commentId, liked),
+      }
+    }
+
+    return comment
+  })
+}
+
+export { useCommentsStore }


### PR DESCRIPTION
## 📌 관련 이슈

> - #88 

## 📑 작업 내용
- supabase realtime과 zustand를 사용하여 댓글 및 대댓글 실시간 반영을 구현하였습니다.
- comments 카운트를 댓글 개수 카운트에서 댓글 및 답글 개수 카운트로 수정하였습니다.
- 댓글이 없을 경우, 댓글이 없다는 멘트가 표시되도록 수정하였습니다.
- 댓글 수정 및 삭제 권한 오류를 수정하였습니다. 
  - 댓글 작성자가 아닌 포스트 작성자가 댓글 및 대댓글 수정, 삭제 권한을 갖도록 되어있었고, 이를 수정

## 🖥️ (Optional) 참고자료

- 스크린샷이나 참고사항을 넣어주세요, 없으실 경우 생략 가능합니다.
