### PR TITLE
feat: empty state 추가 및 UI 통일화

### DIFF
--- a/src/components/common/empty-state.tsx
+++ b/src/components/common/empty-state.tsx
@@ -1,0 +1,37 @@
+import { JSX } from 'react'
+import { Card, CardContent } from '~/components/ui/card'
+
+type EmptyProps = {
+  type: 'card' | 'default'
+  icon?: JSX.Element
+  title: string
+  subTitle?: string
+}
+
+function EmptyState({ type, icon, title, subTitle }: EmptyProps) {
+  const content = (
+    <div className="container mx-auto px-4 pb-6 pt-10">
+      <div className="flex-col items-center justify-center text-center">
+        {icon && (
+          <div className="mb-3 inline-block rounded-full bg-zinc-100 px-5 py-5">
+            {icon}
+          </div>
+        )}
+        <p className="text-lg font-semibold">{title}</p>
+        <p className="text-sm">{subTitle}</p>
+      </div>
+    </div>
+  )
+
+  if (type === 'card') {
+    return (
+      <Card>
+        <CardContent>{content}</CardContent>
+      </Card>
+    )
+  }
+
+  return content
+}
+
+export default EmptyState

--- a/src/components/common/share-button.tsx
+++ b/src/components/common/share-button.tsx
@@ -21,7 +21,7 @@ function ShareButton({
     <Popover>
       <PopoverTrigger asChild>
         <button className="flex items-center">
-          <Share2 size={18} className="mr-1" />
+          <Share2 size={18} className="mr-2" />
           Share
         </button>
       </PopoverTrigger>

--- a/src/components/common/survey-card/survey-card-action.tsx
+++ b/src/components/common/survey-card/survey-card-action.tsx
@@ -33,16 +33,16 @@ export function SurveyCardActions({
       {/* 좋아요 버튼 */}
       <button onClick={onLikeToggle} className="flex items-center">
         {userLiked ? (
-          <Heart size={18} color="red" className="mr-4" strokeWidth={2} />
+          <Heart size={18} color="red" className="mr-2" strokeWidth={2} />
         ) : (
-          <Heart size={18} color="gray" className="mr-4" />
+          <Heart size={18} color="gray" className="mr-2" />
         )}
         {formatLikeCount(initLikeCount)}
       </button>
 
       {/* 댓글 */}
       <Link href={`/survey-detail/${postId}`} className="flex items-center">
-        <MessageSquare size={18} className="mr-1" />
+        <MessageSquare size={18} className="mr-2" />
         {commentsCount}
       </Link>
 

--- a/src/components/common/survey-card/survey-card-body.tsx
+++ b/src/components/common/survey-card/survey-card-body.tsx
@@ -20,7 +20,7 @@ export function SurveyCardBody({
   return pathname === detailPagePath ? (
     // 현재 페이지라면 링크 없이 내용만 렌더링
     <div className="block">
-      <p className="mb-4 min-h-20 rounded-lg bg-gray-50 p-4 text-gray-800">
+      <p className="mb-4 flex min-h-20 items-center rounded-lg bg-gray-50 p-4 text-gray-800">
         {question}
       </p>
       {postImageUrl && (
@@ -36,7 +36,7 @@ export function SurveyCardBody({
   ) : (
     // 현재 페이지가 아니라면 링크로 감싸기
     <Link href={detailPagePath} className="block">
-      <p className="mb-4 min-h-20 rounded-lg bg-gray-50 p-4 text-gray-800">
+      <p className="mb-4 flex min-h-20 items-center rounded-lg bg-gray-50 p-4 text-gray-800">
         {question}
       </p>
       {postImageUrl && (

--- a/src/components/common/survey-card/survey-card-header.tsx
+++ b/src/components/common/survey-card/survey-card-header.tsx
@@ -34,7 +34,7 @@ export function SurveyCardHeader({
   const [isDeleting, setIsDeleting] = useState(false)
 
   const handleDelete = async () => {
-    if (!confirm('정말로 이 게시글을 삭제하시겠습니까?')) return
+    if (!confirm('Are you sure you wand to delete this post?')) return
     setIsDeleting(true)
 
     try {
@@ -49,15 +49,14 @@ export function SurveyCardHeader({
       }
 
       await response.json()
-      alert('게시글이 삭제되었습니다.')
+      alert('The post has been deleted.')
       router.push('/')
       router.refresh()
     } catch (error: unknown) {
-      console.error('게시글 삭제 오류:', error)
       alert(
         error instanceof Error
           ? error.message
-          : '게시글 삭제 중 문제가 발생했습니다.',
+          : 'An error occurred while deleting the post.',
       )
     } finally {
       setIsDeleting(false)
@@ -88,7 +87,7 @@ export function SurveyCardHeader({
       {userId === currentUserId && (
         <DropdownMenu>
           <DropdownMenuTrigger className="rounded p-1 hover:bg-gray-100">
-            <Ellipsis className="text-gray-500" />
+            <Ellipsis className="text-gray-500" size={20} />
           </DropdownMenuTrigger>
           <DropdownMenuContent>
             <DropdownMenuItem>
@@ -99,11 +98,11 @@ export function SurveyCardHeader({
                 }}
                 className="block w-full"
               >
-                편집
+                Edit
               </Link>
             </DropdownMenuItem>
             <DropdownMenuItem onClick={handleDelete} disabled={isDeleting}>
-              {isDeleting ? '삭제 중...' : '삭제'}
+              {isDeleting ? 'Deleting...' : 'Delete'}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/src/components/home/survey-list.tsx
+++ b/src/components/home/survey-list.tsx
@@ -1,6 +1,9 @@
-import { SurveyCard } from '~/components/common/survey-card/survey-card'
-import { fetchUserAuth } from '~/utils/fetch-user-auth'
 import { headers } from 'next/headers'
+import { AppWindowMac } from 'lucide-react'
+
+import { SurveyCard } from '~/components/common/survey-card/survey-card'
+import EmptyState from '~/components/common/empty-state'
+import { fetchUserAuth } from '~/utils/fetch-user-auth'
 
 // 게시글 데이터 타입 정의
 type Post = {
@@ -59,7 +62,18 @@ async function SurveyList({ type, id }: { type: string; id: string | null }) {
     })
 
     const { data }: { data: Post[] } = await res.json()
-    console.log(data)
+
+    // 포스트가 없을 때
+    if (data.length === 0) {
+      return (
+        <EmptyState
+          type="card"
+          icon={<AppWindowMac size={32} />}
+          title="here are no posts yet"
+          subTitle="Start by creating a new survey! "
+        />
+      )
+    }
 
     // 렌더링
     return (

--- a/src/components/survey-detail/reply-input.tsx
+++ b/src/components/survey-detail/reply-input.tsx
@@ -97,8 +97,8 @@ function ReplyInput({
                 <Input
                   {...field}
                   type="text"
-                  className="h-[40px] rounded-[30px] border-0 bg-primary-foreground pl-5 pr-[40px]"
-                  placeholder={`@${username}에게 답글 달기`}
+                  className="h-[40px] rounded-[30px] border-0 bg-primary-foreground pl-5 pr-[40px] text-sm"
+                  placeholder={`Reply to ${username}`}
                 />
               </FormControl>
               <FormMessage className="pl-7" />

--- a/src/components/survey-detail/survey-comment-input.tsx
+++ b/src/components/survey-detail/survey-comment-input.tsx
@@ -69,7 +69,7 @@ function SurveyCommentInput({ postId }: SurveyCommentInputProps) {
               <FormControl className="flex w-full">
                 <Input
                   type="text"
-                  className="h-10 flex-grow rounded-lg border bg-gray-100 pl-5"
+                  className="h-10 flex-grow rounded-lg border bg-gray-100 pl-5 text-sm"
                   placeholder="Add a comment..."
                   {...field}
                 />

--- a/src/components/survey-detail/survey-comment-section.tsx
+++ b/src/components/survey-detail/survey-comment-section.tsx
@@ -2,6 +2,9 @@
 'use client'
 
 import { useEffect, useMemo } from 'react'
+import { MessageSquareDashed } from 'lucide-react'
+
+import EmptyState from '~/components/common/empty-state'
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
 import { SurveyComment } from '~/components/survey-detail/survey-comment'
 import { SurveyCommentInput } from '~/components/survey-detail/survey-comment-input'
@@ -84,7 +87,12 @@ export function CommentsSection({
             />
           ))
         ) : (
-          <p>No Comments Yet</p>
+          <EmptyState
+            type="default"
+            icon={<MessageSquareDashed size={24} />}
+            title="No comments yet"
+            subTitle="Be the first to comment."
+          />
         )}
         <SurveyCommentInput postId={postId} />
       </CardContent>


### PR DESCRIPTION
## 📌 관련 이슈

> - #101

## 📑 작업 내용

리팩토링 작업 이후 스켈레톤 무한실행 이슈가 픽스되어, 아래 작업으로 진행하였습니다.
- Post 및 Comment가 없을 경우 Empty State를 출력합니다.
- Survey Card의 UI를 통일화하였습니다.
  -  한글 메뉴들을 영문으로 통일화하였습니다. (포스트 메뉴, 포스트 삭제 메세지, 답글 placeholder 등)
  - Post의 상호작용(좋아요, 코멘트) 간격을 통일화 하였습니다.  

## 🖥️ (Optional) 참고자료

문구는 약간 수정 되었습니다.

<img width="726" alt="스크린샷 2025-02-11 오후 4 04 49" src="https://github.com/user-attachments/assets/f196413c-89ac-43ee-9c22-d2d18a0ee2dc" />
<img width="761" alt="스크린샷 2025-02-11 오후 3 37 33" src="https://github.com/user-attachments/assets/7435503e-2d64-4622-9b19-2caf5ea30b19" />

